### PR TITLE
fix print error

### DIFF
--- a/berkeley_parse_analyser/print_coloured_errors.py
+++ b/berkeley_parse_analyser/print_coloured_errors.py
@@ -18,7 +18,7 @@ def mprint(text, out_dict, out_name):
 		for key in out_dict:
 			print(text, file=out_dict[key])
 	else:
-		print(text, out_dict[out_name])
+		print(text, file=out_dict[out_name])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I found an error in `mprint` function, which results in print_coloured_errors.py generating wrong output. This bug was made by myself while trying to made the code compatible with python 3.